### PR TITLE
put <ws> in <factor>, not <number>

### DIFF
--- a/misc/calc.raku
+++ b/misc/calc.raku
@@ -10,7 +10,7 @@ grammar Calculator {
     }
 
     rule factor {
-        <value>* %% <op3>
+        <value> * %% <op3>
     }
 
     token op1 {
@@ -30,12 +30,9 @@ grammar Calculator {
         | '(' <TOP> ')'
     }
 
-    rule number {
+    token number {
         \d+
     }
-    # token number {
-    #     <ws> \d+ <ws>
-    # }
 }
 
 class CalculatorActions {


### PR DESCRIPTION
It makes more sense to keep number as a token. The whitespace belongs in factor, which is already a rule and just needs to allow space in the repetitions. This is also better pedantically because it makes it clear to the reader (of the book) exactly where this whitespace is taking effect.